### PR TITLE
add an API to get total count of recursive sub nodes of one node

### DIFF
--- a/zookeeper-common/src/main/java/org/apache/zookeeper/AsyncCallback.java
+++ b/zookeeper-common/src/main/java/org/apache/zookeeper/AsyncCallback.java
@@ -101,6 +101,15 @@ public interface AsyncCallback {
                 Stat stat);
     }
 
+    /*
+   *  This callback is used to get all children node number of the node.
+   * */
+    @InterfaceAudience.Public
+    interface AllChildrenNumberCallback extends AsyncCallback {
+        public void processResult(int rc, String path, Object ctx,
+                                  int number);
+    }
+
     /**
      * This callback is used to retrieve the ACL and stat of the node.
      */

--- a/zookeeper-common/src/main/java/org/apache/zookeeper/ClientCnxn.java
+++ b/zookeeper-common/src/main/java/org/apache/zookeeper/ClientCnxn.java
@@ -616,6 +616,14 @@ public class ClientCnxn {
                       } else {
                           cb.processResult(rc, clientPath, p.ctx, null);
                       }
+                  } else if (p.response instanceof GetAllChildrenNumberResponse) {
+                      AllChildrenNumberCallback cb = (AllChildrenNumberCallback) p.cb;
+                      GetAllChildrenNumberResponse rsp = (GetAllChildrenNumberResponse) p.response;
+                      if (rc == 0) {
+                          cb.processResult(rc, clientPath, p.ctx, rsp.getTotalNumber());
+                      } else {
+                          cb.processResult(rc, clientPath, p.ctx, 0);
+                      }
                   } else if (p.response instanceof GetChildren2Response) {
                       Children2Callback cb = (Children2Callback) p.cb;
                       GetChildren2Response rsp = (GetChildren2Response) p.response;

--- a/zookeeper-common/src/main/java/org/apache/zookeeper/ZooDefs.java
+++ b/zookeeper-common/src/main/java/org/apache/zookeeper/ZooDefs.java
@@ -50,6 +50,8 @@ public class ZooDefs {
 
         public final int getChildren = 8;
 
+        public final int getAllChildrenNumber = 20;
+
         public final int sync = 9;
 
         public final int ping = 11;

--- a/zookeeper-common/src/main/java/org/apache/zookeeper/ZooKeeper.java
+++ b/zookeeper-common/src/main/java/org/apache/zookeeper/ZooKeeper.java
@@ -2495,6 +2495,30 @@ public class ZooKeeper implements AutoCloseable {
         return getChildren(path, watch ? watchManager.defaultWatcher : null);
     }
 
+    /*
+   *  Get all children number of one node
+   * */
+    public int getAllChildrenNumber(final String path)
+            throws KeeperException, InterruptedException {
+        int totalNumber = 0;
+        final String clientPath = path;
+        PathUtils.validatePath(clientPath);
+        // the watch contains the un-chroot path
+        WatchRegistration wcb = null;
+        final String serverPath = prependChroot(clientPath);
+        RequestHeader h = new RequestHeader();
+        h.setType(ZooDefs.OpCode.getAllChildrenNumber);
+        GetAllChildrenNumberRequest request = new GetAllChildrenNumberRequest();
+        request.setPath(serverPath);
+        GetAllChildrenNumberResponse response = new GetAllChildrenNumberResponse();
+        ReplyHeader r = cnxn.submitRequest(h, request, response, wcb);
+        if (r.getErr() != 0) {
+            throw KeeperException.create(KeeperException.Code.get(r.getErr()),
+                    clientPath);
+        }
+        return response.getTotalNumber();
+    }
+
     /**
      * The asynchronous version of getChildren.
      *

--- a/zookeeper-common/src/test/java/org/apache/zookeeper/test/GetAllChildrenNumberTest.java
+++ b/zookeeper-common/src/test/java/org/apache/zookeeper/test/GetAllChildrenNumberTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zookeeper.test;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.data.Stat;
+import org.junit.Assert;
+import org.junit.Test;
+public class GetAllChildrenNumberTest extends ClientBase {
+    private ZooKeeper zk;
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        zk = createClient();
+    }
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        zk.close();
+    }
+    @Test
+    public void testGetChildrenNumber()
+            throws IOException, KeeperException, InterruptedException
+    {
+        String name = "/foo";
+        zk.create(name, name.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        String childname = name + "/bar";
+        zk.create(childname, childname.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        String subname1 = childname + "/child1";
+        String subname1 = childname + "/child2";
+        String subname1 = childname + "/child3";
+        zk.create(subname1, subname1.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        zk.create(childname, childname.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        zk.create(childname, childname.getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        Stat stat = new Stat();
+        int foo_number = zk.getAllChildrenNumber(name);
+        int bar_number = zk.getAllChildrenNumber(childname);
+        int sub_number1 = zk.getAllChildrenNumber(subname1);
+        int sub_number2 = zk.getAllChildrenNumber(subname2);
+        int sub_number3 = zk.getAllChildrenNumber(subname3);
+        Assert.assertEquals(5, foo_number);
+        Assert.assertEquals(4, bar_number);
+        Assert.assertEquals(1, sub_number1);
+        Assert.assertEquals(1, sub_number2);
+        Assert.assertEquals(1, sub_number3);
+    }
+}

--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -142,6 +142,9 @@ module org.apache.zookeeper.proto {
         ustring path;
         boolean watch;
     }
+    class GetAllChildrenNumberRequest {
+        ustring path;
+    }
     class GetChildren2Request {
         ustring path;
         boolean watch;
@@ -205,6 +208,9 @@ module org.apache.zookeeper.proto {
     }
     class GetChildrenResponse {
         vector<ustring> children;
+    }
+    class GetAllChildrenNumberResponse {
+        int totalNumber;
     }
     class GetChildren2Response {
         vector<ustring> children;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -729,6 +729,16 @@ public class DataTree {
         }
     }
 
+    public int getAllChildrenNumber(String path) {
+        int number = 0;
+        for(Map.Entry<String, DataNode> entry : nodes.entrySet()) {
+            String key = entry.getKey();
+            if(key.startsWith(path))
+                number++;
+        }
+        return number;
+    }
+
     public Stat setACL(String path, List<ACL> acl, int version)
             throws KeeperException.NoNodeException {
         Stat stat = new Stat();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/FinalRequestProcessor.java
@@ -385,6 +385,24 @@ public class FinalRequestProcessor implements RequestProcessor {
                 rsp = new GetChildrenResponse(children);
                 break;
             }
+            case OpCode.getAllChildrenNumber: {
+                lastOp = "GETACN";
+                GetAllChildrenNumberRequest getAllChildrenNumberRequest = new
+                        GetAllChildrenNumberRequest();
+                ByteBufferInputStream.byteBuffer2Record(request.request,
+                        getAllChildrenNumberRequest);
+                DataNode n = zks.getZKDatabase().getNode(getAllChildrenNumberRequest.getPath());
+                Long aclG;
+                synchronized(n) {
+                    aclG = n.acl;
+                }
+                PrepRequestProcessor.checkACL(zks, zks.getZKDatabase().convertLong(aclG),
+                        ZooDefs.Perms.READ,
+                        request.authInfo);
+                int number = zks.getZKDatabase().getAllChildrenNumber(getAllChildrenNumberRequest.getPath());
+                rsp = new GetAllChildrenNumberResponse(number);
+                break;
+            }
             case OpCode.getChildren2: {
                 lastOp = "GETC";
                 GetChildren2Request getChildren2Request = new GetChildren2Request();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -854,6 +854,7 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements
             case OpCode.getData:
             case OpCode.getACL:
             case OpCode.getChildren:
+            case OpCode.getAllChildrenNumber:
             case OpCode.getChildren2:
             case OpCode.ping:
             case OpCode.setWatches:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/Request.java
@@ -145,6 +145,7 @@ public class Request {
         case OpCode.exists:
         case OpCode.getACL:
         case OpCode.getChildren:
+        case OpCode.getAllChildrenNumber:
         case OpCode.getChildren2:
         case OpCode.getData:
         case OpCode.multi:
@@ -167,6 +168,7 @@ public class Request {
         case OpCode.exists:
         case OpCode.getACL:
         case OpCode.getChildren:
+        case OpCode.getAllChildrenNumber:
         case OpCode.getChildren2:
         case OpCode.getData:
             return false;
@@ -227,6 +229,8 @@ public class Request {
             return "setACL";
         case OpCode.getChildren:
             return "getChildren";
+        case OpCode.getAllChildrenNumber:
+            return "getAllChildrenNumber";
         case OpCode.getChildren2:
             return "getChildren2";
         case OpCode.ping:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/TraceFormatter.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/TraceFormatter.java
@@ -59,6 +59,8 @@ public class TraceFormatter {
             return "setACL";
         case OpCode.getChildren:
             return "getChildren";
+        case OpCode.getAllChildrenNumber:
+            return "getAllChildrenNumber";
         case OpCode.getChildren2:
             return "getChildren2";
         case OpCode.ping:

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZKDatabase.java
@@ -516,6 +516,14 @@ public class ZKDatabase {
         return dataTree.getChildren(path, stat, watcher);
     }
 
+    /*
+    * get all sub-children number of this node
+    * */
+    public int getAllChildrenNumber(String path)
+            throws KeeperException.NoNodeException {
+        return dataTree.getAllChildrenNumber(path);
+    }
+
     /**
      * check if the path is special or not
      * @param path the input path

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/server/DataTreeTest.java
@@ -301,4 +301,17 @@ public class DataTreeTest extends ZKTestCase {
         dt.deleteNode("/testApproximateDataSize", -1);
         Assert.assertEquals(dt.cachedApproximateDataSize(), dt.approximateDataSize());
     }
+
+    @Test
+    public void testGetAllChildrenNumber() throws Exception {
+        DataTree dt = new DataTree();
+        // create a node
+        dt.createNode("/all_children_test", new byte[20], null, -1, 1, 1, 1);
+        dt.createNode("/all_children_test/nodes", new byte[20], null, -1, 1, 1, 1);
+        dt.createNode("/all_children_test/nodes/node1", new byte[20], null, -1, 1, 1, 1);
+        dt.createNode("/all_children_test/nodes/node2", new byte[20], null, -1, 1, 1, 1);
+        dt.createNode("/all_children_test/nodes/node3", new byte[20], null, -1, 1, 1, 1);
+        Assert.assertEquals(5, dt.getAllChildrenNumber("/all_children_test"));
+        Assert.assertEquals(4, dt.getAllChildrenNumber("/all_children_test/nodes"));
+    }
 }


### PR DESCRIPTION
1. In production environment, there will be always a situation that there are a lot of recursive sub nodes of one node. We need to count total number of it.

2. Now, we can only use API getChildren which returns the List of first level of sub nodes. We need to iterate every sub node to get recursive sub nodes. It will cost a lot of time.

3. In zookeeper server side, it uses Hasp<String, DataNode> to store node. The key of the map represents the path of the node. We can iterate the map get total number of all levels of sub nodes of one node.